### PR TITLE
Mention `nixpkgs-review` for reverse dependencies

### DIFF
--- a/source/faq.rst
+++ b/source/faq.rst
@@ -86,7 +86,7 @@ The solution is to dump the db and use old Nix version to initialize it:
 How to build reverse dependencies of a package?
 -----------------------------------------------
 
-``nix-shell -p nox-review --run "nox-review wip"``
+``nix-shell -p nixpkgs-review --run "nixpkgs-review wip"``
 
 I'm getting: writing to file: Connection reset by peer
 ------------------------------------------------------


### PR DESCRIPTION
nixpkgs-review is a little more featureful, and the tool I see used most often:

```
$ nox-review pr --help
Usage: nox-review pr [OPTIONS] PR

Options:
  --slug TEXT           The GitHub "slug" of the repository in the from of
                        owner_name/repo_name.

  --token TEXT          The GitHub API token to use.
  --merge / --no-merge  Merge the PR against its base.
  --help                Show this message and exit.
```
vs
```
$ nixpkgs-review pr --help
usage: /nix/store/c3gzcqs77cv54i7k7hr01ffdasr3d2ar-nixpkgs-review-2.3.1/bin/nixpkgs-review pr
       [-h] [--eval {ofborg,local}] [-c {merge,commit}] [--post-result] [--build-args BUILD_ARGS] [-p PACKAGE]
       [--package-regex PACKAGE_REGEX] [--no-shell] [--token TOKEN]
       number [number ...]

positional arguments:
  number                one or more nixpkgs pull request numbers (ranges are also supported)

optional arguments:
  -h, --help            show this help message and exit
  --eval {ofborg,local}
                        Whether to use ofborg's evaluation result
  -c {merge,commit}, --checkout {merge,commit}
                        What to source checkout when building: `merge` will merge the pull request into the target branch,
                        while `commit` will checkout pull request as the user has committed it
  --post-result         Post the nixpkgs-review results as a PR comment
  --build-args BUILD_ARGS
                        arguments passed to nix when building
  -p PACKAGE, --package PACKAGE
                        Package to build (can be passed multiple times)
  --package-regex PACKAGE_REGEX
                        Regular expression that package attributes have to match (can be passed multiple times)
  --no-shell            Only evaluate and build without executing nix-shell
  --token TOKEN         Github access token (optional if request limit exceeds)
```