### PR TITLE
Refer to gitignoresource in case of ./. anti pattern

### DIFF
--- a/source/anti-patterns/language.rst
+++ b/source/anti-patterns/language.rst
@@ -175,6 +175,6 @@ A better way is to use ``builtins.path``:
   }
 
 
-
-
-
+If you're using git to track your code,
+you may also want to look at `gitignoresource <https://github.com/hercules-ci/gitignore.nix>`_,
+which does this for you. 


### PR DESCRIPTION
Knowing about that significantly increased the ergonimics
of nix-shell for me. So I think it's good to mention it.