### PR TITLE
Remove semi-colon from fetchTarball example

### DIFF
--- a/source/tutorials/towards-reproducibility-pinning-nixpkgs.rst
+++ b/source/tutorials/towards-reproducibility-pinning-nixpkgs.rst
@@ -32,7 +32,7 @@ The simplest way to do this is to fetch the required nixpkgs version as a tarbal
 
 .. code:: nix
 
-    { pkgs ? import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/3590f02e7d5760e52072c1a729ee2250b5560746.tar.gz") {};
+    { pkgs ? import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/3590f02e7d5760e52072c1a729ee2250b5560746.tar.gz") {}
     }:
 
     ...


### PR DESCRIPTION
When trying to follow the example, it would not work, but removing the semi-colon made it work. I am not sure if the problem is on my side, but I am taking a chance assuming the problem is in the documentation and therefore submitting this pull request.