### PR TITLE
Showcase `inherit` as an alternative to `with`

### DIFF
--- a/source/anti-patterns/language.rst
+++ b/source/anti-patterns/language.rst
@@ -71,14 +71,31 @@ There are a number of problems with such approach:
 
 - Scoping rules around ``with`` are not intuitive, see `Nix issue for details <https://github.com/NixOS/nix/issues/490>`_
 
-A better way is to use a variable:
+Here are some better alternatives:
 
 .. code:: nix
 
+    # instead of:
+    with (import <nixpkgs> {});
+
+    # try this instead:
     let
       pkgs = import <nixpkgs> {};
+      inherit (pkgs) curl jq;
     in ...
 
+.. code:: nix
+
+    # instead of:
+    buildInputs = with pkgs; [ curl jq ];
+
+    # try this instead:
+    buildInputs = builtins.attrValues {
+      inherit (pkgs) curl jq;
+    };
+
+    # or this:
+    buildInputs = lib.attrVals ["curl" "jq"] pkgs
 
 ``<...>`` search path
 ---------------------


### PR DESCRIPTION
Hello,

It seems to me that `with` is used to reduce the repetition of fetching from an attrset, providing an alternative that simply ignores this intent does not "feel right".
Bringing attributes into scope is something that `inherit` does well, so I've been using it whenever I would use `with`.

The example I've added below the original one is something I've started doing as well whenever I want to use `with` in a list, lists don't "feel particularly good" to me a lot of the time, so I default to building an attr instead and I turn it into a list via `builtins.attrValues`. This has downsides: you can't repeat values if they have the same name, and I'm not sure if there are any guarantees in regards to the ordering. This does not matter in some cases however (`buildInputs`).
An alternative could be to use `lib.attrVals` but you have to start juggling with lists if you need attributes from more than just one attrset.

Feel free to reject/ask for changes, I mainly wanted to initiate discussion, creating an issue seemed redundant.

Thanks