### PR TITLE
Replace all mentions of 20.03 with 21.05

### DIFF
--- a/source/reference/pinning-nixpkgs.rst
+++ b/source/reference/pinning-nixpkgs.rst
@@ -19,11 +19,11 @@ Possible ``URL`` values
 
 - Pinned to a specific commit: ``https://github.com/NixOS/nixpkgs/archive/addcb0dddf2b7db505dae5c38fceb691c7ed85f9.tar.gz``
 
-- Using latest channel, meaning all tests have passed: ``http://nixos.org/channels/nixos-20.03/nixexprs.tar.xz``
+- Using latest channel, meaning all tests have passed: ``http://nixos.org/channels/nixos-21.05/nixexprs.tar.xz``
 
-- Using latest channel, but hosted by github: ``https://github.com/NixOS/nixpkgs/archive/nixos-20.03.tar.gz``
+- Using latest channel, but hosted by github: ``https://github.com/NixOS/nixpkgs/archive/nixos-21.05.tar.gz``
 
-- Using latest commit for release branch, but not tested yet: ``https://github.com/NixOS/nixpkgs/archive/release-20.03.tar.gz``
+- Using latest commit for release branch, but not tested yet: ``https://github.com/NixOS/nixpkgs/archive/release-21.05.tar.gz``
 
 
 Examples
@@ -31,12 +31,12 @@ Examples
 
 - ``nix-build -I ~/dev``
 - ``nix-build -I ~/dev``
-- ``nix-build -I nixpkgs=http://nixos.org/channels/nixos-20.03/nixexprs.tar.xz``
-- ``NIX_PATH=nixpkgs=http://nixos.org/channels/nixos-20.03/nixexprs.tar.xz nix-build ...``
+- ``nix-build -I nixpkgs=http://nixos.org/channels/nixos-21.05/nixexprs.tar.xz``
+- ``NIX_PATH=nixpkgs=http://nixos.org/channels/nixos-21.05/nixexprs.tar.xz nix-build ...``
 - Using just Nix::
 
     let
-      pkgs = import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/nixos-20.03.tar.gz") {};
+      pkgs = import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/nixos-21.05.tar.gz") {};
     in pkgs.stdenv.mkDerivation { … }
 
 - To make ad-hoc environment available on NixOS: ``nix.nixPath = [ ("nixpkgs=" + toString pkgs.path) ];``

--- a/source/tutorials/deploying-nixos-using-terraform.rst
+++ b/source/tutorials/deploying-nixos-using-terraform.rst
@@ -51,7 +51,7 @@ Booting NixOS image
 
     module "nixos_image" {
         source  = "git::https://github.com/tweag/terraform-nixos.git//aws_image_nixos?ref=5f5a0408b299874d6a29d1271e9bffeee4c9ca71"
-        release = "20.09"
+        release = "21.05"
     }
 
     resource "aws_security_group" "ssh_and_egress" {
@@ -106,7 +106,7 @@ The only NixOS specific snippet is:
 
    module "nixos_image" {
      source = "git::https://github.com/tweag/terraform-nixos.git/aws_image_nixos?ref=5f5a0408b299874d6a29d1271e9bffeee4c9ca71"
-     release = "20.09"
+     release = "21.05"
    }
 
 .. note::

--- a/source/tutorials/deploying-nixos-using-terraform.rst
+++ b/source/tutorials/deploying-nixos-using-terraform.rst
@@ -51,7 +51,7 @@ Booting NixOS image
 
     module "nixos_image" {
         source  = "git::https://github.com/tweag/terraform-nixos.git//aws_image_nixos?ref=5f5a0408b299874d6a29d1271e9bffeee4c9ca71"
-        release = "21.05"
+        release = "20.09"
     }
 
     resource "aws_security_group" "ssh_and_egress" {
@@ -106,7 +106,7 @@ The only NixOS specific snippet is:
 
    module "nixos_image" {
      source = "git::https://github.com/tweag/terraform-nixos.git/aws_image_nixos?ref=5f5a0408b299874d6a29d1271e9bffeee4c9ca71"
-     release = "21.05"
+     release = "20.09"
    }
 
 .. note::

--- a/source/tutorials/towards-reproducibility-pinning-nixpkgs.rst
+++ b/source/tutorials/towards-reproducibility-pinning-nixpkgs.rst
@@ -42,7 +42,7 @@ which lists all the releases and the latest commit that has passed all tests.
 
 When choosing a commit, it is recommended to follow either
 
-* the **latest stable NixOS** release by using a specific version, such as ``nixos-20.03``, **or**
+* the **latest stable NixOS** release by using a specific version, such as ``nixos-21.05``, **or**
 * the latest **unstable release** via ``nixos-unstable``.
 
 Dependency management with niv
@@ -65,7 +65,7 @@ You can see which version ``niv`` is tracking as follow:
 
 And you can change the tracking branch to the one you want like this:
 
-    $ niv modify nixpkgs --branch nixos-20.03
+    $ niv modify nixpkgs --branch nixos-21.05
 
 
 


### PR DESCRIPTION
I think this is pretty self explanatory, there isnt much point of keeping the website to reference an outdated channel. 