### PR TITLE
cross-compilation: fix platform terminology in shell example

### DIFF
--- a/source/tutorials/cross-compilation.rst
+++ b/source/tutorials/cross-compilation.rst
@@ -239,9 +239,9 @@ Given we have a ``shell.nix``:
 
   # callPackage is needed due to https://github.com/NixOS/nixpkgs/pull/126844
   pkgs.pkgsStatic.callPackage ({ mkShell, zlib, pkg-config, file }: mkShell {
-    # these tools run on the build platform, but are configured to target the target platform
+    # these tools run on the build platform, but are configured to target the host platform
     nativeBuildInputs = [ pkg-config file ];
-    # libraries needed for the target platform
+    # libraries needed for the host platform
     buildInputs = [ zlib ];
   }) {}
 


### PR DESCRIPTION
* `nativeBuildInputs` is roughly equivalent to taking a package from `buildPackages` which
  means that *its* host platform is the build platform of the derivation (so we can execute it during
  the build) and its target platform is the host platform of the derivation (so e. g. compilers produce
  binaries that can be executed where we want them to)
* `buildInputs` are needed on the *host* platform of the derivation
* What would the target platform be in this case? It would only be relevant if we were to build a
  cross-compiler: Then we'd need runtime libraries for the target platform, for example.