### PR TITLE
new hydra link to the aarch64 sd image

### DIFF
--- a/source/tutorials/installing-nixos-on-a-raspberry-pi.rst
+++ b/source/tutorials/installing-nixos-on-a-raspberry-pi.rst
@@ -7,7 +7,7 @@ Installing NixOS on a Raspberry Pi
 
 This tutorial assumes `Raspberry P 4 Model B with 4GB RAM <https://www.raspberrypi.org/products/raspberry-pi-4-model-b/>`_.
 
-Before starting this tutorial, make sure you have 
+Before starting this tutorial, make sure you have
 `all necessary hardware <https://projects.raspberrypi.org/en/projects/raspberry-pi-setting-up/1>`_:
 
 - HDMI cable/adapter.
@@ -16,7 +16,7 @@ Before starting this tutorial, make sure you have
 - Power cable for your Raspberry Pi.
 - USB keyboard.
 
-.. note:: 
+.. note::
 
   This tutorial was written for the Raspberry Pi 4B. Using a previous supported revision, like the 3B or 3B+, is possible with tweaks.
 
@@ -31,12 +31,12 @@ Prepare the AArch64 image on your laptop:
 .. code:: shell-session
 
   $ nix-shell -p wget zstd
-  $ wget https://hydra.nixos.org/build/142828023/download/1/nixos-sd-image-21.05pre288297.8eed0e20953-aarch64-linux.img.zst
-  $ unzstd -d nixos-sd-image-21.05pre288297.8eed0e20953-aarch64-linux.img.zst
+  $ wget https://hydra.nixos.org/build/160738647/download/1/nixos-sd-image-22.05pre335501.c71f061c68b-aarch64-linux.img.zst
+  $ unzstd -d nixos-sd-image-22.05pre335501.c71f061c68b-aarch64-linux.img.zst
   $ dmesg --follow
 
 .. note::
-  You can pick a newer image by going to `Hydra job <https://hydra.nixos.org/job/nixos/trunk-combined/nixos.sd_image_new_kernel.aarch64-linux>`_,
+  You can pick a newer image by going to `Hydra job <https://hydra.nixos.org/job/nixos/trunk-combined/nixos.sd_image.aarch64-linux>`_,
   clicking on a build and copying the link to the build product image.
 
 Your terminal should be printing kernel messages as they come in.
@@ -47,7 +47,7 @@ Press ``ctrl-c`` to stop ``dmesg --follow``.
 
 Copy NixOS to your SD card by replacing ``sdX`` with the name of your device:
 
-.. code:: shell-session 
+.. code:: shell-session
 
   sudo dd if=nixos-sd-image-21.05pre288297.8eed0e20953-aarch64-linux.img of=/dev/sdX bs=4096 conv=fsync status=progress
 
@@ -69,12 +69,12 @@ At this point we'll need internet connection. If you can use an ethernet cable, 
 In case you're connecting to a wifi run ``iwconfig`` to see what is the name of your wireless
 network interface. In case it's ``wlan0`` replace ``SSID`` and ``passphrase`` with your data and run:
 
-.. code:: shell-session 
+.. code:: shell-session
 
   # wpa_supplicant -B -i wlan0 -c <(wpa_passphrase 'SSID' 'passphrase') &
 
 
-Once you see in your terminal that connection is established, run ``host nixos.org`` to 
+Once you see in your terminal that connection is established, run ``host nixos.org`` to
 check that DNS resolves correctly.
 
 In case you've made a typo, run ``pkill wpa_supplicant`` and start over.
@@ -91,14 +91,14 @@ To benefit from updates and bug fixes from the vendor, we'll start by updating R
   # mount /dev/disk/by-label/FIRMWARE /mnt
   # BOOTFS=/mnt FIRMWARE_RELEASE_STATUS=stable rpi-eeprom-update -d -a
 
-  
-Installing NixOS 
+
+Installing NixOS
 ----------------
 
 For initial installation we'll install `XFCE <https://www.xfce.org/>`_ desktop environment
 with user ``guest`` and SSH daemon.
 
-.. code:: nix 
+.. code:: nix
 
   { config, pkgs, lib, ... }:
 
@@ -158,7 +158,7 @@ To save time on typing the whole configuration, download it:
 
 .. code:: shell-session
 
-  # curl -L https://tinyurl.com/nixos-rpi4-tutorial > /etc/nixos/configuration.nix 
+  # curl -L https://tinyurl.com/nixos-rpi4-tutorial > /etc/nixos/configuration.nix
 
 At the top of `/etc/nixos/configuration.nix` there are a few variables that you want to configure,
 most important being your wifi connection details, this time specified in declarative way.
@@ -173,7 +173,7 @@ Once you're ready to install NixOS:
 In case your system doesn't boot, select the oldest configuration in the bootloader menu to get back to live image and start over.
 
 
-Making changes 
+Making changes
 --------------
 
 It booted, congratulations!
@@ -181,7 +181,7 @@ It booted, congratulations!
 To make further changes to the configuration, `search through NixOS options <https://search.nixos.org/options>`_,
 edit ``/etc/nixos/configuration.nix`` and update your system:
 
-.. code:: shell-session 
+.. code:: shell-session
 
   $ sudo -i
   # nixos-rebuild switch
@@ -192,7 +192,7 @@ Next steps
 
 - Once you have successfully running OS, try upgrading it with `nixos-rebuild switch --upgrade`
   and reboot to the old configuration if something broke.
-  
+
 - To tweak bootloader options affecting hardware, `see config.txt options <https://www.raspberrypi.org/documentation/configuration/config-txt/>`_
   and change the options by runnning ``mount /dev/disk/by-label/FIRMWARE /mnt`` and opening ``/mnt/config.txt``.
 


### PR DESCRIPTION
Looks like the `new_kernel` variant no longer exists.

I used the plain `nixos.sd_image` image and managed to get my RPi4 up and running with it.