### PR TITLE
Fix broken links after recent update to nix/nipkgs manuals

### DIFF
--- a/source/faq.rst
+++ b/source/faq.rst
@@ -130,7 +130,7 @@ NixOS
 How to build my own ISO?
 ------------------------
 
-http://nixos.org/nixos/manual/index.html#sec-building-cd
+http://nixos.org/nixos/manual/index.html#sec-building-image
 
 How do I connect to any of the machines in NixOS tests?
 -------------------------------------------------------

--- a/source/reference/pinning-nixpkgs.rst
+++ b/source/reference/pinning-nixpkgs.rst
@@ -9,7 +9,7 @@ Different ways:
 
 - ``-I`` command line parameter to most of commands like ``nix-build``, ``nix-shell``, etc
 
-- Using `builtins.fetchTarball <https://nixos.org/nix/manual/#ssec-builtins>`_ function that fetches the channel at evaluation time
+- Using `builtins.fetchTarball <https://nixos.org/manual/nix/stable/expressions/builtins.html>`_ function that fetches the channel at evaluation time
 
 
 Possible ``URL`` values

--- a/source/tutorials/ad-hoc-developer-environments.rst
+++ b/source/tutorials/ad-hoc-developer-environments.rst
@@ -177,7 +177,7 @@ We've only covered the bare essentials of Nix here. Once you're comfortable with
 
 - :ref:`declarative-reproducible-envs`
 
-- `Garbage Collection <https://nixos.org/nix/manual/#sec-garbage-collection>`_- as when using `nix-shell`, packages are downloaded into `/nix/store`, but never removed.
+- `Garbage Collection <https://nixos.org/manual/nix/stable/package-management/garbage-collection.html>`_- as when using `nix-shell`, packages are downloaded into `/nix/store`, but never removed.
 
 - See ``man nix-shell`` for all of the options.
 

--- a/source/tutorials/contributing.rst
+++ b/source/tutorials/contributing.rst
@@ -62,11 +62,11 @@ contributors.
 Feel free to `join our community`_ of developers!
 
 .. _GitHub: https://github.com/
-.. _how to setup a development environment: https://nixos.org/nix/manual/#chap-hacking
+.. _how to setup a development environment: https://nixos.org/manual/nix/stable/contributing/hacking.html
 .. _reported issues: https://github.com/NixOS/nix/issues
 .. _join our community: https://github.com/NixOS/nixpkgs#community
-.. _The manual: https://nixos.org/nixpkgs/manual/#chap-quick-start
-.. _programming language specific instructions: https://nixos.org/nixpkgs/manual/#chap-language-support
+.. _The manual: https://nixos.org/manual/nix/stable/quick-start.html
+.. _programming language specific instructions: https://nixos.org/manual/nixpkgs/stable/#chap-language-support
 .. _nixpkgs: https://github.com/NixOS/nixpkgs
-.. _NixOS manual: https://nixos.org/nixos/manual/index.html#ch-development
+.. _NixOS manual: https://nixos.org/manual/nixos/stable/index.html#ch-development
 .. _issues tagged with good-first-bug: https://github.com/NixOS/nixpkgs/labels/3.skill%3A%20good-first-bug

--- a/source/tutorials/install-nix.rst
+++ b/source/tutorials/install-nix.rst
@@ -20,7 +20,7 @@ Install Nix on via the recommended `multi-user installation <https://nixos.org/m
 macOS
 -----
 
-Install Nix on via the recommended `multi-user installation <https://nixos.org/manual/nix/stable/#chap-installation>`_:
+Install Nix via the recommended `multi-user installation <https://nixos.org/manual/nix/stable/installation/multi-user.html>`_:
 
 .. code:: bash
 
@@ -35,7 +35,7 @@ Install Nix on via the recommended `multi-user installation <https://nixos.org/m
 Windows (WSL2)
 --------------
 
-Install Nix on via the recommended `single-user installation <https://nixos.org/manual/nix/stable/#chap-installation>`_:
+Install Nix via the recommended `single-user installation <https://nixos.org/manual/nix/stable/installation/single-user.html>`_:
 
 .. code:: bash
 

--- a/source/tutorials/install-nix.rst
+++ b/source/tutorials/install-nix.rst
@@ -6,7 +6,7 @@ Install Nix
 Linux
 -----
 
-Install Nix on via the recommended `multi-user installation <https://nixos.org/manual/nix/stable/#chap-installation>`_:
+Install Nix on via the recommended `multi-user installation <https://nixos.org/manual/nix/stable/installation/multi-user.html>`_:
 
 .. code:: bash
 


### PR DESCRIPTION
A bunch of URLs changed with the recent updates to nix/nixpkgs manuals. This PR fixes the links so they point to new URLs.