### PR TITLE
Update archive urls

### DIFF
--- a/source/tutorials/ad-hoc-developer-environments.md
+++ b/source/tutorials/ad-hoc-developer-environments.md
@@ -121,7 +121,7 @@ Nix also offers fully reproducible environments, which it calls pure environment
 The following is a fully reproducible example and something that different colleagues with different machines, for example, could share.
 
 ```shell-session
-$ nix-shell --pure -p git -I nixpkgs=https://github.com/NixOS/nixpkgs/archive/82b5f87fcc710a99c47c5ffe441589807a8202af.tar.gz
+$ nix-shell --pure -p git -I nixpkgs=https://hydra.nixos.org/build/169230332/download/2/nixpkgs-21.11pre336538.64fc73bd74f.tar.xz
 
 [nix-shell:~]$ git --version
 git version 2.25.4
@@ -141,7 +141,7 @@ and share with strangers online. As long as they have Nix installed, they'll be 
 ```python
 #! /usr/bin/env nix-shell
 #! nix-shell --pure -i python -p "python38.withPackages (ps: [ ps.django ])"
-#! nix-shell -I nixpkgs=https://github.com/NixOS/nixpkgs/archive/82b5f87fcc710a99c47c5ffe441589807a8202af.tar.gz
+#! nix-shell -I nixpkgs=https://hydra.nixos.org/build/169230332/download/2/nixpkgs-21.11pre336538.64fc73bd74f.tar.xz
 
 import django
 


### PR DESCRIPTION
I was still hitting #219 even with `nix --veersion` of 2.7.0

Updating the nixpkgs archive url to the latest fixes it.

The final comment in this thread which I believe to be the cause says no fix will be backported
- https://github.com/NixOS/nix/pull/5543


