### PR TITLE
nixos-configuration-on-vm: de-emphasize `nixos-generate-config`

### DIFF
--- a/source/tutorials/nixos/nixos-configuration-on-vm.md
+++ b/source/tutorials/nixos/nixos-configuration-on-vm.md
@@ -26,7 +26,8 @@ For a thorough treatment of the module system, check the [](module-system-deep-d
 ## Starting from a default NixOS configuration
 
 :::{note}
-This tutorial starts with building up your `configuration.nix` from first principles, explaining each step. If you prefer, you can skip ahead to the [sample configuration](sample-nixos-config) section.
+This tutorial starts with building up your `configuration.nix` from first principles, explaining each step.
+If you prefer, you can skip ahead to the [sample configuration](sample-nixos-config) section.
 :::
 
 We start with a minimal `configuration.nix`:


### PR DESCRIPTION
The main point of `nixos-generate-config` is that it generates the `hardware-configuration.nix` matching the characteristics of the machine you're running on, but that configuration is not used in the VM scenario anyway.

I think it distracts from the main message of this tutorial, especially as there's some outstanding bugs in `nixos-generate-config` that you might get confused by, such as https://github.com/NixOS/nixpkgs/issues/417803

I'd suggest removing the `nixos-generate-config` content from this tutorial. Possibly we could have it return as a dedicated tutorial at some point.