### PR TITLE
.github: fix up CODEOWNERS for late 2025

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,12 +13,10 @@
 
 * @NixOS/documentation-team
 
-/.github/workflows/ @asymmetric
+# CI lives here
+/.github @philiptaron @Mic92
 
 /source/tutorials/file-sets.md @infinisil
-source/guides/recipes/dependency-management.md @infinisil
-source/guides/recipes/python-environment.md @alejandrosame
-source/tutorials/module-system @infinisil @asymmetric @proofconstruction
-source/tutorials/packaging-existing-software.md @proofconstruction
-
-/maintainers/documentation-survey.md @henrik-ch
+/source/guides/recipes/dependency-management.md @infinisil
+/source/guides/recipes/python-environment.md @alejandrosame
+/source/tutorials/module-system @infinisil


### PR DESCRIPTION
I noticed that this wasn't being marked by GitHub as valid any more.