### PR TITLE
Disable tests for packages that timeout on aarch64-darwin

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -15,6 +15,17 @@ let
   pkgs-pinned = import inputs.nixpkgs."23.11" {
     config = { };
     inherit system;
+    # Several packages have tests that timeout on aarch64-darwin, disable them
+    overlays = [
+      (final: prev: {
+        graphite2 = prev.graphite2.overrideAttrs (old: {
+          doCheck = false;
+        });
+        p11-kit = prev.p11-kit.overrideAttrs (old: {
+          doCheck = false;
+        });
+      })
+    ];
   };
   nix-dev-python-pkgs = with pkgs-pinned.python3.pkgs; [
     linkify-it-py


### PR DESCRIPTION
Building on aarch64-darwin fails because p11-kit tests timeout, which cascades into gnutls and eventually sphinx not being available.

This adds an overlay to disable tests for p11-kit and graphite2 on this platform.


Here's the relevant error from the initial build:
```
  > Ok:                 56
  > Expected Fail:      0
  > Fail:               0
  > Unexpected Pass:    0
  > Skipped:            0
  > Timeout:            2
  >
  > Full log written to /nix/var/nix/builds/nix-14437-1783282361/source/build/meson-logs/testlog.txt
  For full logs, run:
    nix log /nix/store/ph1h78hg21av397ksi56jz4cxycklrh7-p11-kit-0.25.0.drv
  error: Cannot build '/nix/store/7xyd715sfvq4kwxsakmyb6fk86c0z6xv-gnutls-3.8.3.drv'.
         Reason: 1 dependency failed.
  error: Cannot build '/nix/store/was41lix7r8n2jknx3xbq2gl0prj784j-ffmpeg-headless-6.0.drv'.
         Reason: 1 dependency failed.
  error: Cannot build '/nix/store/6mmdm9d4j78dj3df7qhscy5d4g3pzil6-python3.11-matplotlib-3.8.0.drv'.
         Reason: 1 dependency failed.
  error: Cannot build '/nix/store/74r06ccan50f2fd0i0myr9rc8kq3cmki-python3.11-pytest-regressions-2.5.0.drv'.
         Reason: 1 dependency failed.
  error: Cannot build '/nix/store/ygf0n6ggy1zjkwlfhadrrrpyw4xzxslh-python3.11-myst-parser-2.0.0.drv'.
         Reason: 1 dependency failed.
  error: build of '/nix/store/8ap2dgg9gbn9w39z4pjvxrnzljlv4x5k-python3.11-sphinx-design-0.5.0.drv',
  '/nix/store/cqjmifqxb55cp7dim2kg0zdc6adwy1gv-python3.11-linkify-it-py-2.0.2.drv', '/nix/store/ik81xi879br298sgylhg5n501vr5aa0c-python3.11-sphinx-notfound-page-1.0.0.drv',
  '/nix/store/jvil11j53gh149f2vfxh3ic0r70pi8nx-python3.11-sphinx-book-theme-1.0.1.drv', '/nix/store/mgibap6460rmr0v2dqhnla55mwinbihz-python3.11-sphinx-copybutton-0.5.2.drv',
  '/nix/store/mjfis3gmqpll4mbig3xmwzj8f4dy04g5-python3.11-sphinx-sitemap-2.5.1.drv', '/nix/store/wmsxy483iyqpzblv0q7sq8xxxi6i0cxb-python3.11-sphinx-7.2.6.drv',
  '/nix/store/ygf0n6ggy1zjkwlfhadrrrpyw4xzxslh-python3.11-myst-parser-2.0.0.drv' failed
  sphinx-build -b html -d build/doctrees  -W source build/html
  make: sphinx-build: No such file or directory
  make: *** [html] Error 1
```