### PR TITLE
clarify flakes as erring to implicit management of recursive dependencies

### DIFF
--- a/source/concepts/flakes.md
+++ b/source/concepts/flakes.md
@@ -88,7 +88,7 @@ This overview can help get what you need from flakes while preserving compatibil
 
 [dependency management]: https://nix.dev/guides/recipes/dependency-management.html
 
-[^flake-inputs]: Nix repositories offering only flake entrypoints may be import using [`flake-inputs`].
+[^flake-inputs]: Nix repositories offering only flake entrypoints may be imported using [`flake-inputs`].
 
 ### Discoverability
 


### PR DESCRIPTION
while i'm not sure this is the right place for this, i think defaulting to implicit management of recursive dependencies is currently a feature that sets it apart from competing dependency management systems for Nix. in my understanding, that makes this a relevant consideration in whether one might choose to adopt them.

i.e., if one wants a better `apt` offering packages that (individually) span multiple nixy repositories, flakes may well be the closest thing they can find right now.

on the other hand, if one is coding a project themselves, i.e. may want more control over their (recursive) dependencies, then this distinguishing feature in itself may be sufficient reason to opt to pass up on them, at least for the purpose of a default mode of dependency management.
