### PR TITLE
explain managing nixos configurations by npins

### DIFF
--- a/source/guides/recipes/dependency-management.md
+++ b/source/guides/recipes/dependency-management.md
@@ -116,7 +116,7 @@ To instead use a `nixpkgs` version managed by `npins`, one can manually override
 sudo NIX_PATH="nixos-config=configuration.nix:nixpkgs=$(nix-instantiate --raw --eval npins -A nixpkgs.outPath)" nixos-rebuild switch
 ```
 
-To make such pinned dependencies available as [look-up paths](../tutorials/nix-language.html#lookup-paths) (like `<nixpkgs>`) while using the NixOS configuration, one may use:
+To make such pinned dependencies available as [look-up paths](https://nix.dev/tutorials/nix-language.html#lookup-paths) (like `<nixpkgs>`) while using the NixOS configuration, one may use:
 
 ```nix
 # configuration.nix


### PR DESCRIPTION
inspired by [jade's article](https://jade.fyi/blog/pinning-nixos-with-npins/). they further mentioned setting up flake commands (nix v3 cli) to use `npins`'s `nixpkgs` pin, which nowadays translates to setting [`nixpkgs.flake.source`](https://search.nixos.org/options?channel=unstable&show=nixpkgs.flake.source&query=nixpkgs.flake.source).