### PR TITLE
update build to latest nixpkgs version, fixing theme changes

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -11,12 +11,7 @@
 let
   lib = pkgs.lib;
   releases = import ./nix/releases.nix { inherit lib inputs system; };
-  # Sphinx skin got very ugly in 24.05, let's not bump it without fixing that
-  pkgs-pinned = import inputs.nixpkgs."23.11" {
-    config = { };
-    inherit system;
-  };
-  nix-dev-python-pkgs = with pkgs-pinned.python3.pkgs; [
+  nix-dev-python-pkgs = with pkgs.python3.pkgs; [
     linkify-it-py
     myst-parser
     sphinx

--- a/source/_static/css/custom.css
+++ b/source/_static/css/custom.css
@@ -1,10 +1,15 @@
-:root {
-  --sd-color-card-border-hover: var(--pst-color-primary) !important;
+html[data-theme="light"] {
+  /* NixOS branding's Argentinian Blue L55 */
+  --pst-color-primary: #2579ab !important;
+  /* NixOS branding's Afghani Blue L55 */
+  --pst-color-secondary: #506fb2 !important;
 }
 
-div.highlight-shell-session + div.highlight-none pre {
-  background-color: var(--pst-color-preformatted-text),1 !important;
-  color: var(--pst-color-preformatted-background),1 !important;
+html[data-theme="dark"] {
+  /* NixOS branding's Argentinian Blue L65 */
+  --pst-color-primary: #3d98d1 !important;
+  /* NixOS branding's Afghani Blue L65 */
+  --pst-color-secondary: #698dd8 !important;
 }
 
 div.expression > div.highlight > pre::before {
@@ -64,10 +69,6 @@ html[data-theme="dark"] .highlight .gd {
   color: inherit !important;
 }
 
-.topic {
-  padding: 30px;
-}
-
 .bd-links {
   padding-bottom: 0 !important;
 }
@@ -96,7 +97,7 @@ html[data-theme="dark"] .highlight .gd {
   margin-bottom: 0.5rem;
 }
 
-.navbar-nav li.toctree-l1 > .toctree-toggle {
+.navbar-nav li.toctree-l1 > details > summary > .toctree-toggle {
   display: none;
 }
 
@@ -104,24 +105,6 @@ html[data-theme="dark"] .highlight .gd {
   font-weight: 600;
 }
 
-.navbar-nav li.toctree-l1 > ul {
+.navbar-nav li.toctree-l1 > details > ul {
   padding: 0;
-}
-
-html[data-theme="dark"] details {
-  background-color: #323c537d;
-  border: 1px solid #323c537d;
-}
-
-html[data-theme="light"] details {
-  background-color: #abc8debf;
-  border: 1px solid #abc8debf;
-}
-
-tml[data-theme="dark"] details a {
-  color: #6097c1;
-}
-
-html[data-theme="light"] details a {
-  color: #0042aa;
 }


### PR DESCRIPTION
Also, since the primary/secondary colors changed with the theme upgrade, I took the liberty to choose some Nix-specific colors, taken from the Nix branding guide.

<details>
<summary>Before</summary>
<img width="1336" height="574" alt="image" src="https://github.com/user-attachments/assets/519e1291-bb37-4f40-96af-9ef2eb2cfadf" />
</details>

<details>
<summary>After</summary>
<img width="1328" height="577" alt="image" src="https://github.com/user-attachments/assets/d57af142-7594-4657-8f61-4ea5876f108a" />
</details>