### PR TITLE
/concepts/flakes: add dependency management alternative `flake = false;`

### DIFF
--- a/source/concepts/flakes.md
+++ b/source/concepts/flakes.md
@@ -254,6 +254,7 @@ Alternatives:
 
 - Handle dependencies with [`npins`].
 - Handle dependencies inline using functions such as the [fetchers] or [`builtins.fetchTree`].
+- Use `inputs.<name>.flake = false;`
 
 [fetchers]: https://nixos.org/manual/nixpkgs/stable/#chap-pkgs-fetchers
 [`flake-inputs`]: https://github.com/fricklerhandwerk/flake-inputs


### PR DESCRIPTION
clarifies that specifying `flake = false;` on flake inputs can help resolve some of its drawbacks - in this case (if used consistently) getting [duplicate versions](https://zimbatm.com/notes/1000-instances-of-nixpkgs) and having to set `follows`. (this would not solve eager fetching, which would instead be addressed by [lazy trees](https://github.com/NixOS/nix/pull/13225).)

to make it more explicit what alternatives address what, a proper approach might be #1212.