### PR TITLE
fix github star button not respecting the dark theme

### DIFF
--- a/source/_static/css/custom.css
+++ b/source/_static/css/custom.css
@@ -108,3 +108,7 @@ html[data-theme="dark"] .highlight .gd {
 .navbar-nav li.toctree-l1 > details > ul {
   padding: 0;
 }
+
+html[data-theme="dark"] iframe[title="GitHub"] {
+  filter: invert(0.93) hue-rotate(100deg);
+}


### PR DESCRIPTION
This is not a complete fix but I think it works well enough and the change is minimal.

The correct thing to do would be to integrate the theme with the ghbtns.com iframe but [seems there is no dark theme yet](https://github.com/mdo/github-buttons/issues/129).

Before the fix:
<img width="515" height="416" alt="image" src="https://github.com/user-attachments/assets/d6d41679-8531-4d66-b000-acc617dd3484" />

After the fix:
<img width="470" height="376" alt="image" src="https://github.com/user-attachments/assets/fc32fc42-da90-4879-8326-be59b7143d41" />
