### PR TITLE
docs(install-nix): add installation instructions for fedora

### DIFF
--- a/source/install-nix.md
+++ b/source/install-nix.md
@@ -20,7 +20,6 @@ On Fedora, you can [install Nix via `dnf`](https://src.fedoraproject.org/rpms/ni
 
 ::::
 
-
 ::::{tab-item} macOS
 
 Install Nix via the recommended [multi-user installation]:


### PR DESCRIPTION
nix is available in Fedora official repositories as announced in https://discourse.nixos.org/t/nix-package-manager-now-available-in-fedora/73932.

https://src.fedoraproject.org/rpms/nix