### PR TITLE
docs: update declarative-shell.md shellHook comment

### DIFF
--- a/source/tutorials/first-steps/declarative-shell.md
+++ b/source/tutorials/first-steps/declarative-shell.md
@@ -151,7 +151,7 @@ If you need to override these protected environment variables, use the `shellHoo
 
 ## Startup commands
 
-You may want to run some commands after the shell environment has initialized.
+You may want to run some shell commands before entering the interactive shell environment.
 These commands can be placed in the `shellHook` attribute provided to `mkShellNoCC`.
 
 Set `shellHook` to output a colorful greeting:


### PR DESCRIPTION
I believe the comment about when the shellHook attribute is executed as a command should be updated to after initialisation and not before entering the shell environment. How would the bash command have access to those packages before that environment designed to fetch those packages is setup? I think this is also consistent with the note on shellHook described here: https://nix.dev/tutorials/nix-language#worked-examples

Please disregard this pull request if my understanding is wrong!