### PR TITLE
Add documentation vision

### DIFF
--- a/maintainers/vision.md
+++ b/maintainers/vision.md
@@ -82,13 +82,13 @@ A small set of high-value workflows for newcomers:
 
 These guides are concise, opinionated where appropriate, and link directly into reference documentation.
 
-## Documentation vs wiki
+## docs.nixos.org vs wiki
 
-Documentation is curated, reviewed, and authoritative. It covers common and important workflows, stays maintained over time, and does not need to cover every edge case.
+docs.nixos.org is curated, reviewed, and authoritative. It covers common and important workflows, stays maintained over time, and does not need to cover every edge case.
 
 The wiki is community-driven and fast-moving. It covers niche topics, experiments, early ideas, and rapidly evolving information. It acts as a documentation incubator.
 
-When a wiki topic becomes widely useful and commonly referenced, it moves into documentation. When it's niche or experimental, it stays in the wiki.
+When a wiki topic becomes widely useful and commonly referenced, it can move into docs.nixos.org. When it's niche or experimental, it stays in the wiki.
 
 ## Ownership and governance
 

--- a/maintainers/vision.md
+++ b/maintainers/vision.md
@@ -8,15 +8,15 @@ The core idea is simple: If others understand where we're going, they can contri
 
 Following our own documentation principles — **show, don't tell** — let's look at a successful example that follows the [Diataxis](https://diataxis.fr/) documentation framework:
 
-- [**MDN Web Docs.**](https://developer.mozilla.org/) Rather than trying to document "the Web" as one giant thing, MDN breaks it into well defined ecosystems: HTML, CSS, JavaScript, and Web APIs. These are immediately visible in navigation, so that users can orient themselves and move between domains as needed.
+- [**MDN Web Docs.**](https://developer.mozilla.org/) Rather than trying to document "the Web" as one giant thing, MDN breaks it into well-defined domains: HTML, CSS, JavaScript, and Web APIs. These are immediately visible in navigation, so that users can orient themselves and move between domains as needed.
 
-  Within each ecosystem, MDN consistently distinguishes between two types of documentation:
+  Within each domain, MDN consistently distinguishes between two types of documentation:
   - **Reference documentation**, optimized for experienced users who know what they're looking for. It answers: How do I call this function? What exactly does this option do? Is this feature supported in my environment?
   - **Guides and tutorials**, optimized for learning and problem-solving. They explain how to accomplish concrete goals, often by combining multiple technologies. For example: ["Adding interactivity"](https://developer.mozilla.org/en-US/docs/Learn_web_development/Getting_started/Your_first_website/Adding_interactivity) connects HTML, CSS, and JavaScript in a practical way.
 
 ## Applying these insights to NixOS
 
-The Nix ecosystem faces similar challenges. We're not documenting a single product, but multiple tightly connected ecosystems:
+The Nix ecosystem faces similar challenges. We're not documenting a single product, but multiple tightly connected components:
 
 - **Nix** (the executable / package manager)
 - The **Nix language**
@@ -24,7 +24,7 @@ The Nix ecosystem faces similar challenges. We're not documenting a single produ
 - **lib** (the standard library)
 - **NixOS** (the operating system and its configuration options)
 
-As a user understanding the distinction but also the connection between the different ecosystems is a key learning. Interconnected documentation for these ecosystems is a prerequisite for this.
+As a user, understanding the distinction but also the connection between these components is a key learning. Interconnected documentation is a prerequisite for this.
 
 ## The vision
 
@@ -32,7 +32,7 @@ Long-term, we want a single authoritative documentation portal at [docs.nixos.or
 
 - Serves as the source of truth for official Nix and NixOS documentation
 - Clearly separates reference documentation from guides and tutorials
-- Is structured by ecosystem, making ownership and navigation obvious
+- Is structured by component, making ownership and discoverability obvious
 - Encourages incremental improvements and small pull requests
 
 **A concrete roadmap for achieving this vision will be maintained separately and updated regularly as we make progress.**
@@ -40,7 +40,7 @@ Long-term, we want a single authoritative documentation portal at [docs.nixos.or
 This means following some core principles:
 
 - **Clear, accessible language.** Documentation should be understandable by as many people as possible without oversimplifying technical reality.
-- **Structured by ecosystem.** Each major part should have complete reference documentation and curated guides for common workflows.
+- **Structured by component.** Each major part should have complete reference documentation and curated guides for common workflows.
 - **Consolidation over duplication.** Where we already have sufficient content, we should move it into the right place, improve structure and cross-linking, and reduce scattered or redundant explanations.
 - **Examples over explanation.** Following the "show, don't tell" principle from the start, documentation should provide concrete, working examples that readers can adapt to their needs.
 
@@ -67,19 +67,19 @@ If a topic becomes widely useful and commonly referenced, it should be refined a
 
 ## Ownership and governance
 
-- Each ecosystem has designated maintainers responsible for keeping reference documentation accurate.
-- The documentation team coordinates cross-ecosystem efforts, maintains shared infrastructure, and reviews contributions.
+- Each component has designated maintainers responsible for keeping reference documentation accurate.
+- The documentation team coordinates cross-cutting efforts, maintains shared infrastructure, and reviews contributions.
 
 ## Maintenance and sustainability
 
-Documentation is curated and maintained by the documentation team in collaboration with the wider community. This ensures content remains accurate, relevant, and aligned with the overall structure of the ecosystem. Sustainable documentation requires not only contributions, but ongoing maintenance and coordination.
+Documentation is curated and maintained by the documentation team in collaboration with the wider community. This ensures content remains accurate, relevant, and aligned with the overall structure. Sustainable documentation requires not only contributions, but ongoing maintenance and coordination.
 
 ## What success looks like
 
 - New users can install and use NixOS without relying on external blogs
 - Common workflows are documented once, clearly, and authoritatively
 - Contributors know where to add or improve content
-- Fewer outdated links and contradictory explanations across the ecosystem
+- Fewer outdated links and contradictory explanations across all components
 
 ## Get involved
 

--- a/maintainers/vision.md
+++ b/maintainers/vision.md
@@ -2,7 +2,7 @@
 
 High-quality documentation is a prerequisite for growth, adoption, and contributor sustainability in the Nix ecosystem. This vision aligns contributors around a shared direction, lowers the barrier to contribution, and ensures documentation serves both newcomers and experienced users.
 
-The core idea: if others understand where we're going, they can contribute in small or large steps toward it.
+The core idea: if others understand where the documentation team is going, they can contribute in small or large steps toward it.
 
 ## Learning from other projects
 
@@ -88,11 +88,11 @@ docs.nixos.org is curated, reviewed, and authoritative. It covers common and imp
 
 The wiki is community-driven and fast-moving. It covers niche topics, experiments, early ideas, and rapidly evolving information. It acts as a documentation incubator.
 
-When a wiki topic becomes widely useful and commonly referenced, it can move into docs.nixos.org. When it's niche or experimental, it stays in the wiki.
+When a wiki topic becomes widely useful and commonly referenced, it can move into docs.nixos.org. When it's niche or experimental, it can stay in the wiki.
 
 ## Ownership and governance
 
-Each component has designated maintainers responsible for keeping reference documentation accurate. The documentation team coordinates cross-cutting efforts, maintains shared infrastructure, and reviews contributions.
+Maintainers of components are responsible for keeping reference documentation of their components accurate. The documentation team coordinates cross-cutting efforts, maintains shared infrastructure, and reviews contributions.
 
 ## Maintenance and sustainability
 

--- a/maintainers/vision.md
+++ b/maintainers/vision.md
@@ -1,0 +1,90 @@
+# NixOS documentation vision
+
+High-quality documentation is a prerequisite for growth, adoption, and contributor sustainability in the Nix ecosystem. This vision is aimed at aligning contributors around a shared direction, lowering the barrier to contribution, and ensuring documentation serves both newcomers and experienced users effectively.
+
+The core idea is simple: If others understand where we're going, they can contribute in small or large steps towards it.
+
+## Learning from other projects
+
+Following our own documentation principles — **show, don't tell** — let's look at a successful example that follows the [Diataxis](https://diataxis.fr/) documentation framework:
+
+- [**MDN Web Docs.**](https://developer.mozilla.org/) Rather than trying to document "the Web" as one giant thing, MDN breaks it into well defined ecosystems: HTML, CSS, JavaScript, and Web APIs. These are immediately visible in navigation, so that users can orient themselves and move between domains as needed.
+
+  Within each ecosystem, MDN consistently distinguishes between two types of documentation:
+  - **Reference documentation**, optimized for experienced users who know what they're looking for. It answers: How do I call this function? What exactly does this option do? Is this feature supported in my environment?
+  - **Guides and tutorials**, optimized for learning and problem-solving. They explain how to accomplish concrete goals, often by combining multiple technologies. For example: ["Adding interactivity"](https://developer.mozilla.org/en-US/docs/Learn_web_development/Getting_started/Your_first_website/Adding_interactivity) connects HTML, CSS, and JavaScript in a practical way.
+
+## Applying these insights to NixOS
+
+The Nix ecosystem faces similar challenges. We're not documenting a single product, but multiple tightly connected ecosystems:
+
+- **Nix** (the executable / package manager)
+- The **Nix language**
+- **nixpkgs** (the package set)
+- **lib** (the standard library)
+- **NixOS** (the operating system and its configuration options)
+
+As a user understanding the distinction but also the connection between the different ecosystems is a key learning. Interconnected documentation for these ecosystems is a prerequisite for this.
+
+## The vision
+
+Long-term, we want a single authoritative documentation portal at [docs.nixos.org]() that:
+
+- Serves as the source of truth for official Nix and NixOS documentation
+- Clearly separates reference documentation from guides and tutorials
+- Is structured by ecosystem, making ownership and navigation obvious
+- Encourages incremental improvements and small pull requests
+
+**A concrete roadmap for achieving this vision will be maintained separately and updated regularly as we make progress.**
+
+This means following some core principles:
+
+- **Clear, accessible language.** Documentation should be understandable by as many people as possible without oversimplifying technical reality.
+- **Structured by ecosystem.** Each major part should have complete reference documentation and curated guides for common workflows.
+- **Consolidation over duplication.** Where we already have sufficient content, we should move it into the right place, improve structure and cross-linking, and reduce scattered or redundant explanations.
+- **Examples over explanation.** Following the "show, don't tell" principle from the start, documentation should provide concrete, working examples that readers can adapt to their needs.
+
+## Getting started guides (high priority)
+
+We should explicitly prioritize a small set of high-value workflows, especially for newcomers:
+
+- How to install NixOS (target: ~15 minutes, end-to-end)
+- How to add packages and services
+- How to manage system configuration safely
+- How to upgrade and recover a system
+
+These guides should be concise, approachable, opinionated where appropriate, and link directly into further reference documentation.
+
+## Documentation vs wiki
+
+Documentation and wiki serve different but complementary roles.
+
+Documentation is curated, reviewed, and authoritative. It focuses on common and important workflows, stays stable and maintained over time, and doesn't need to cover every edge case.
+
+The wiki is community-driven and fast-moving. It's a space for niche topics, experiments and early ideas, and rapidly evolving information. It acts as a documentation incubator, not a replacement for documentation, but a feeder and experimentation space.
+
+If a topic becomes widely useful and commonly referenced, it should be refined and moved into documentation. If it's niche or experimental, it belongs in the wiki.
+
+## Ownership and governance
+
+- Each ecosystem has designated maintainers responsible for keeping reference documentation accurate.
+- The documentation team coordinates cross-ecosystem efforts, maintains shared infrastructure, and reviews contributions.
+
+## Maintenance and sustainability
+
+Documentation is curated and maintained by the documentation team in collaboration with the wider community. This ensures content remains accurate, relevant, and aligned with the overall structure of the ecosystem. Sustainable documentation requires not only contributions, but ongoing maintenance and coordination.
+
+## What success looks like
+
+- New users can install and use NixOS without relying on external blogs
+- Common workflows are documented once, clearly, and authoritatively
+- Contributors know where to add or improve content
+- Fewer outdated links and contradictory explanations across the ecosystem
+
+## Get involved
+
+We explicitly invite everyone who cares about NixOS documentation to get involved.
+
+You don't need to write large guides to contribute. Valuable contributions include improving clarity and structure, adding links and cross-references, consolidating existing content, turning commonly used wiki pages into polished documentation, reviewing and maintaining existing pages. Small, incremental pull requests are encouraged and highly valued.
+
+Joining doesn't require prior documentation experience or large time commitments. Contributions can range from occasional small improvements to more sustained involvement.

--- a/maintainers/vision.md
+++ b/maintainers/vision.md
@@ -1,90 +1,121 @@
 # NixOS documentation vision
 
-High-quality documentation is a prerequisite for growth, adoption, and contributor sustainability in the Nix ecosystem. This vision is aimed at aligning contributors around a shared direction, lowering the barrier to contribution, and ensuring documentation serves both newcomers and experienced users effectively.
+High-quality documentation is a prerequisite for growth, adoption, and contributor sustainability in the Nix ecosystem. This vision aligns contributors around a shared direction, lowers the barrier to contribution, and ensures documentation serves both newcomers and experienced users.
 
-The core idea is simple: If others understand where we're going, they can contribute in small or large steps towards it.
+The core idea: if others understand where we're going, they can contribute in small or large steps toward it.
 
 ## Learning from other projects
 
-Following our own documentation principles — **show, don't tell** — let's look at a successful example that follows the [Diataxis](https://diataxis.fr/) documentation framework:
+Following our own documentation principle — show, don't tell — here is a successful example using the [Diataxis](https://diataxis.fr/) framework:
 
-- [**MDN Web Docs.**](https://developer.mozilla.org/) Rather than trying to document "the Web" as one giant thing, MDN breaks it into well-defined domains: HTML, CSS, JavaScript, and Web APIs. These are immediately visible in navigation, so that users can orient themselves and move between domains as needed.
+[**MDN Web Docs**](https://developer.mozilla.org/) breaks the web platform into well-defined domains: HTML, CSS, JavaScript, and Web APIs. These are immediately visible in navigation, so you can orient yourself and move between domains as needed.
 
-  Within each domain, MDN consistently distinguishes between two types of documentation:
-  - **Reference documentation**, optimized for experienced users who know what they're looking for. It answers: How do I call this function? What exactly does this option do? Is this feature supported in my environment?
-  - **Guides and tutorials**, optimized for learning and problem-solving. They explain how to accomplish concrete goals, often by combining multiple technologies. For example: ["Adding interactivity"](https://developer.mozilla.org/en-US/docs/Learn_web_development/Getting_started/Your_first_website/Adding_interactivity) connects HTML, CSS, and JavaScript in a practical way.
+Within each domain, MDN consistently separates two types of documentation:
+
+- **Reference documentation**, for users who know what they're looking for. It answers: how do I call this function? What does this option do? Is this feature supported in my environment?
+- **Guides and tutorials**, for learning and problem-solving. They explain how to accomplish concrete goals, often combining multiple technologies. For example: ["Adding interactivity"](https://developer.mozilla.org/en-US/docs/Learn_web_development/Getting_started/Your_first_website/Adding_interactivity) connects HTML, CSS, and JavaScript in a practical way.
 
 ## Applying these insights to NixOS
 
-The Nix ecosystem faces similar challenges. We're not documenting a single product, but multiple tightly connected components:
+The Nix ecosystem documents several tightly connected components:
 
-- **Nix** (the executable / package manager)
-- The **Nix language**
-- **nixpkgs** (the package set)
-- **lib** (the standard library)
-- **NixOS** (the operating system and its configuration options)
+- **Nix** — the package manager and build tool
+- **The Nix language**
+- **nixpkgs** — the package set
+- **lib** — the standard library
+- **NixOS** — the operating system and its configuration options
 
-As a user, understanding the distinction but also the connection between these components is a key learning. Interconnected documentation is a prerequisite for this.
+Understanding the distinction between these components — and the connection between them — is itself a key learning. Interconnected documentation is a prerequisite for that.
+
+But components are not how users think. Users ask questions like:
+
+- How do I run nginx on NixOS?
+- What options does the PostgreSQL service expose?
+- Which packages provide this tool?
 
 ## The vision
 
-Long-term, we want a single authoritative documentation portal at [docs.nixos.org]() that:
+Long-term, a single authoritative documentation portal at [docs.nixos.org]() that:
 
 - Serves as the source of truth for official Nix and NixOS documentation
-- Clearly separates reference documentation from guides and tutorials
-- Is structured by component, making ownership and discoverability obvious
+- Separates reference documentation from guides and tutorials
+- Structures content by component, making ownership and discoverability obvious
+- Lets you navigate by application or service, not only by component
 - Encourages incremental improvements and small pull requests
 
-**A concrete roadmap for achieving this vision will be maintained separately and updated regularly as we make progress.**
+**A concrete roadmap for achieving this vision is maintained separately and updated regularly.**
 
-This means following some core principles:
+Core principles:
 
-- **Clear, accessible language.** Documentation should be understandable by as many people as possible without oversimplifying technical reality.
-- **Structured by component.** Each major part should have complete reference documentation and curated guides for common workflows.
-- **Consolidation over duplication.** Where we already have sufficient content, we should move it into the right place, improve structure and cross-linking, and reduce scattered or redundant explanations.
-- **Examples over explanation.** Following the "show, don't tell" principle from the start, documentation should provide concrete, working examples that readers can adapt to their needs.
+- **Clear, accessible language.** Documentation is understandable without oversimplifying technical reality.
+- **Structured by component.** Each major part has complete reference documentation and curated guides for common workflows.
+- **Consolidation over duplication.** Move existing content into the right place, improve structure and cross-linking, and reduce scattered or redundant explanations.
+- **Examples over explanation.** Concrete, working examples come first. Readers can adapt them to their needs.
+- **Reference docs derive from source.** Where source code carries structured annotations, reference documentation is generated from it. This keeps docs accurate as the source evolves.
+
+## Application and service navigation
+
+You can browse documentation by service or application, not only by component. For example, navigating to nginx surfaces:
+
+- The relevant `services.nginx.*` options, grouped by submodule
+- Related packages
+- Guides for common workflows
+
+This view does not duplicate content. It connects existing reference data to the user-level question: how do I run this?
+
+## Search
+
+Search works across all components simultaneously. You can:
+
+- Search by option path (`services.postgresql`) and see matching options, related packages, and relevant guides
+- Filter by component (nixpkgs, NixOS options, lib, guides)
+- Find a service's full option set without knowing the exact module path in advance
 
 ## Getting started guides (high priority)
 
-We should explicitly prioritize a small set of high-value workflows, especially for newcomers:
+A small set of high-value workflows for newcomers:
 
-- How to install NixOS (target: ~15 minutes, end-to-end)
+- How to install NixOS — target: under 15 minutes, end to end
 - How to add packages and services
 - How to manage system configuration safely
 - How to upgrade and recover a system
 
-These guides should be concise, approachable, opinionated where appropriate, and link directly into further reference documentation.
+These guides are concise, opinionated where appropriate, and link directly into reference documentation.
 
 ## Documentation vs wiki
 
-Documentation and wiki serve different but complementary roles.
+Documentation is curated, reviewed, and authoritative. It covers common and important workflows, stays maintained over time, and does not need to cover every edge case.
 
-Documentation is curated, reviewed, and authoritative. It focuses on common and important workflows, stays stable and maintained over time, and doesn't need to cover every edge case.
+The wiki is community-driven and fast-moving. It covers niche topics, experiments, early ideas, and rapidly evolving information. It acts as a documentation incubator.
 
-The wiki is community-driven and fast-moving. It's a space for niche topics, experiments and early ideas, and rapidly evolving information. It acts as a documentation incubator, not a replacement for documentation, but a feeder and experimentation space.
-
-If a topic becomes widely useful and commonly referenced, it should be refined and moved into documentation. If it's niche or experimental, it belongs in the wiki.
+When a wiki topic becomes widely useful and commonly referenced, it moves into documentation. When it's niche or experimental, it stays in the wiki.
 
 ## Ownership and governance
 
-- Each component has designated maintainers responsible for keeping reference documentation accurate.
-- The documentation team coordinates cross-cutting efforts, maintains shared infrastructure, and reviews contributions.
+Each component has designated maintainers responsible for keeping reference documentation accurate. The documentation team coordinates cross-cutting efforts, maintains shared infrastructure, and reviews contributions.
 
 ## Maintenance and sustainability
 
-Documentation is curated and maintained by the documentation team in collaboration with the wider community. This ensures content remains accurate, relevant, and aligned with the overall structure. Sustainable documentation requires not only contributions, but ongoing maintenance and coordination.
+The documentation team support community driven maintenance of documentation. This keeps content accurate, relevant, and aligned with the overall structure.
 
 ## What success looks like
 
-- New users can install and use NixOS without relying on external blogs
+- You can find all relevant information in one place
+- You can install and use NixOS without relying on external blogs
 - Common workflows are documented once, clearly, and authoritatively
 - Contributors know where to add or improve content
 - Fewer outdated links and contradictory explanations across all components
 
 ## Get involved
 
-We explicitly invite everyone who cares about NixOS documentation to get involved.
+Everyone who cares about NixOS documentation is explicitly invited to contribute.
 
-You don't need to write large guides to contribute. Valuable contributions include improving clarity and structure, adding links and cross-references, consolidating existing content, turning commonly used wiki pages into polished documentation, reviewing and maintaining existing pages. Small, incremental pull requests are encouraged and highly valued.
+You don't need to write large guides. Valuable contributions include:
 
-Joining doesn't require prior documentation experience or large time commitments. Contributions can range from occasional small improvements to more sustained involvement.
+- Improving clarity and structure
+- Adding links and cross-references
+- Consolidating existing content
+- Turning commonly referenced wiki pages into polished documentation
+- Reviewing and maintaining existing pages
+
+Small, incremental pull requests are encouraged and highly valued.


### PR DESCRIPTION
As part of the revival of the documenation team @hsjobeki and me have drafted a new vision for 
the NixOS documentation. Based on this we will launch efforts to restructure the current documentation as well as a funraising campaign to finance those efforts. 

Here is a small teaser:
> Our vision extends toward a unified documentation portal that clearly separates reference material from practical guides, organized by ecosystem for easy navigation. We’re working to consolidate scattered resources, reduce duplication, and establish a single source of truth for the community. The roadmap includes prioritized getting-started guides for common workflows like installation, package management, and system recovery. We also distinguish between curated documentation and the community wiki, allowing each to serve its distinct purpose. Together, these efforts aim to lower barriers for newcomers while preserving the depth experienced users rely on.

For more details read the diff ;)

FYI: @roberth, @infinisil
