### PR TITLE
source/conf.py: Remove Back to Top button

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -152,6 +152,7 @@ html_theme_options = {
     "path_to_docs": "source",
     "use_repository_button": True,
     "show_navbar_depth": 2,
+    "back_to_top_button": False,
 }
 
 


### PR DESCRIPTION
Closes #1182

This stops the "Back to Top" button from appearing by setting a [theme option](https://pydata-sphinx-theme.readthedocs.io/en/stable/user_guide/back-to-top.html) to turn it off!