### PR TITLE
concepts/flakes: remove unimplemented null input

### DIFF
--- a/source/concepts/flakes.md
+++ b/source/concepts/flakes.md
@@ -234,9 +234,6 @@ You can override these if you want using `follows` statements:
 
 This way, Home Manager's inputs reuse your chosen `nixpkgs`.
 
-If you don't want to load a dependency, you can also disable it.
-In the above example, that could look like `inputs.home-manager.inputs.nixpkgs = null;`.
-
 Pros:
 
 - Make it easy to reproduce published software, following the versions they used.


### PR DESCRIPTION
This feature is currently not implemented and fails during evaluation with `error: expected a set but got null`.

Discussed in https://github.com/NixOS/nix/issues/7807. The thread talks about alternatives/workarounds but they're all opinionated and have downsides, so I think it's best to just delete the lines for now.