### PR TITLE
guides/recpies: shell rename build -> package

### DIFF
--- a/source/guides/recipes/sharing-dependencies.md
+++ b/source/guides/recipes/sharing-dependencies.md
@@ -13,12 +13,12 @@ Use the [`inputsFrom` attribute to `pkgs.mkShellNoCC`](https://nixos.org/manual/
 # default.nix
 let
   pkgs = import <nixpkgs> {};
-  build = pkgs.callPackage ./build.nix {};
+  myPackage = pkgs.callPackage ./package.nix {};
 in
 {
-  inherit build;
+  inherit myPackage;
   shell = pkgs.mkShellNoCC {
-    inputsFrom = [ build ];
+    inputsFrom = [ myPackage ];
   };
 }
 ```
@@ -32,10 +32,10 @@ Import the `shell` attribute in `shell.nix`:
 
 ## Complete example
 
-Assume your build is defined in `build.nix`:
+Assume your package is defined in `package.nix`:
 
 ```nix
-# build.nix
+# package.nix
 { cowsay, runCommand }:
 runCommand "cowsay-output" { buildInputs = [ cowsay ]; } ''
   cowsay Hello, Nix! > $out
@@ -53,7 +53,7 @@ let
   pkgs = import nixpkgs { config = {}; overlays = []; };
 in
 {
-  build = pkgs.callPackage ./build.nix {};
+  myPackage = pkgs.callPackage ./package.nix {};
 }
 ```
 
@@ -66,26 +66,26 @@ Add an attribute to `default.nix` specifying an environment:
    pkgs = import nixpkgs { config = {}; overlays = []; };
  in
  {
-   build = pkgs.callPackage ./build.nix {};
+   myPackage = pkgs.callPackage ./package.nix {};
 +  shell = pkgs.mkShellNoCC {
 +  };
  }
 ```
 
-Move the `build` attribute into the `let` binding to be able to re-use it.
+Move the `myPackage` attribute into the `let` binding to be able to re-use it.
 Then take the package's dependencies into the environment with [`inputsFrom`](https://nixos.org/manual/nixpkgs/stable/#sec-pkgs-mkShell-attributes):
 
 ```diff
  let
    nixpkgs = fetchTarball "https://github.com/NixOS/nixpkgs/tarball/nixos-23.11";
    pkgs = import nixpkgs { config = {}; overlays = []; };
-+  build = pkgs.callPackage ./build.nix {};
++  myPackage = pkgs.callPackage ./package.nix {};
  in
  {
--  build = pkgs.callPackage ./build.nix {};
-+  inherit build;
+-  myPackage = pkgs.callPackage ./package.nix {};
++  inherit myPackage;
    shell = pkgs.mkShellNoCC {
-+    inputsFrom = [ build ];
++    inputsFrom = [ myPackage ];
    };
  }
 ```

--- a/source/tutorials/working-with-local-files.md
+++ b/source/tutorials/working-with-local-files.md
@@ -109,7 +109,7 @@ let
     inherit system;
   };
 in
-pkgs.callPackage ./build.nix { }
+pkgs.callPackage ./package.nix { }
 ```
 
 Add two source files to work with:


### PR DESCRIPTION
Rationale: name the thing, not the process