### PR TITLE
site/banner: display red banner on all pages

### DIFF
--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -22,6 +22,7 @@ export default defineConfig({
         },
       ],
       components: {
+        Banner: "./src/components/Banner.astro",
         Header: "./src/components/Header.astro",
         Sidebar: "./src/components/Sidebar.astro",
       },

--- a/site/src/components/Banner.astro
+++ b/site/src/components/Banner.astro
@@ -1,0 +1,32 @@
+---
+const message = "Prototype. Expect breaking changes. Contribute on ";
+---
+
+<div class="sl-banner global-banner" data-pagefind-ignore>
+  <span aria-hidden="true">🚧</span>
+  <strong>{message}</strong><a
+    href="https://github.com/nixos/nix.dev"
+    target="_blank"
+    rel="noopener noreferrer">GitHub</a
+  >
+  <span aria-hidden="true"> 🚧</span>
+</div>
+
+<style>
+  @layer starlight.core {
+    .sl-banner.global-banner {
+      padding: 1rem var(--sl-nav-pad-x);
+      background-color: #d21c1c;
+      color: #fff;
+      font-size: var(--sl-text-lg);
+      font-weight: 700;
+      line-height: var(--sl-line-height-headings);
+      text-align: center;
+      text-wrap: balance;
+      box-shadow: var(--sl-shadow-sm);
+    }
+    .sl-banner.global-banner :global(a) {
+      color: #fff;
+    }
+  }
+</style>

--- a/site/src/content/docs/index.mdx
+++ b/site/src/content/docs/index.mdx
@@ -1,9 +1,6 @@
 ---
 title: NixOS documentation
 description: The documentation for the NixOS project — Nix, NixOS, and Nixpkgs — with guides and references in one place.
-banner:
-  content: |
-    <strong>Prototype</strong> — evaluation build. Reference pages are synthetic and non-authoritative.
 template: splash
 hero:
   tagline: Guides and references for Nix, NixOS, and Nixpkgs.


### PR DESCRIPTION
The prototype uses the default "banner" which is blue (informative).

This PR switches to a red banner with construction emojis, to make it clear that this is a prototype