### PR TITLE
fix instructions to optionally build manuals in devmode

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,8 +33,13 @@ By default, nix.dev builds without the various versions of the Nix reference man
 To enable building the manuals:
 
 ```shell-session
-[nix-shell:nix.dev]$ nix-build -A build --arg withManuals true
-[nix-shell:nix.dev]$ devmode --arg withManuals true
+$ nix-build -A build --arg withManuals true
+```
+
+Or for interactive development:
+
+```shell-session
+$ nix-shell --arg withManuals true --run devmode
 ```
 
 ## Updating reference manuals

--- a/default.nix
+++ b/default.nix
@@ -51,7 +51,7 @@ let
         };
       in
       ''
-        ${lib.optionalString withManuals "cp -f ${substitutedNixManualReference} source/reference/nix-manual.md"}
+        cp -f ${substitutedNixManualReference} source/reference/nix-manual.md
         make html
         make latexpdf
       '';
@@ -89,10 +89,15 @@ let
       '';
   };
 
-  devmode = pkgs.devmode.override {
-    buildArgs = ''-A build --show-trace'';
-    open = "/index.html";
-  };
+  devmode =
+    let
+      boolean = x: if x then "true" else "false";
+    in
+
+    pkgs.devmode.override {
+      buildArgs = "-A build --show-trace --arg withManuals ${boolean withManuals}";
+      open = "/index.html";
+    };
   update-nix-releases = pkgs.callPackage ./nix/update-nix-releases.nix { };
   update-nixpkgs-releases = pkgs.callPackage ./nix/update-nixpkgs-releases.nix { };
 in

--- a/shell.nix
+++ b/shell.nix
@@ -1,1 +1,1 @@
-(import ./. { }).shell
+args@{ ... }: (import ./. args).shell


### PR DESCRIPTION
This also fixes the local display of links to the Nix manuals when
they're disabled.