### PR TITLE
link to module system tutorial as next steps

### DIFF
--- a/source/tutorials/nix-language.md
+++ b/source/tutorials/nix-language.md
@@ -2126,9 +2126,7 @@ Different language ecosystems and frameworks have different requirements to acco
 
 - [Languages and frameworks][language-support] lists tools provided by Nixpkgs to build language- or framework-specific packages with Nix.
 
-The NixOS Linux distribution has a modular configuration system that imposes its own conventions:
-
-- [NixOS modules][nixos-modules] shows how NixOS configurations are organized.
+The NixOS Linux distribution uses a [modular configuration system](module-system-tutorial) that imposes its own conventions.
 
 [nix-pills]: https://nixos.org/guides/nix-pills/
 [stdenv]: https://nixos.org/manual/nixpkgs/stable/#chap-stdenv


### PR DESCRIPTION
The NixOS reference manual is of no help in this context, because it
doesn't explain anything about what the module system is and how it
works, which users at this point can't be expected to know.