### PR TITLE
shell: fix direnv provides 'inNixShell'as argument

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -7,6 +7,7 @@
     inherit system;
   },
   withManuals ? false, # building the manuals is expensive
+  inNixShell ? false # Provided by direnv-nix; Ignored for now.
 }:
 let
   lib = pkgs.lib;


### PR DESCRIPTION
See: 'https://github.com/nix-community/nix-direnv/blob/1b09e07427e03ec0197060df33030a64290132f0/direnvrc#L561'