### PR TITLE
fix(netlify): use download/2 for manual redirects

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,6 @@
 [[redirects]]
 from = "/manual/nix/unstable/*"
-to = "https://hydra.nixos.org/job/nix/master/manual/latest/download/1/manual/:splat"
+to = "https://hydra.nixos.org/job/nix/master/manual/latest/download/2/manual/:splat"
 status = 200
 force = true
 [redirects.headers]
@@ -8,7 +8,7 @@ X-From = "nix.dev-Uogho3gi"
 
 [[redirects]]
 from = "/manual/nix/development/*"
-to = "https://hydra.nixos.org/job/nix/master/manual/latest/download/1/manual/:splat"
+to = "https://hydra.nixos.org/job/nix/master/manual/latest/download/2/manual/:splat"
 status = 200
 force = true
 [redirects.headers]


### PR DESCRIPTION
Update Hydra download path from `download/1` to `download/2` for the Nix manual redirect rules.

The previous index was stale, causing broken links to the Nix development manual.

See also https://github.com/NixOS/nix/pull/16178.