### PR TITLE
Update instructions for adding GitHub secrets

### DIFF
--- a/source/guides/recipes/continuous-integration-github-actions.md
+++ b/source/guides/recipes/continuous-integration-github-actions.md
@@ -36,8 +36,9 @@ On your freshly created binary cache, follow the **Push binaries** tab instructi
 On your GitHub repository or organization (for use across all repositories):
 
 1. Click on `Settings`.
-2. Click on `Secrets`.
-3. Add your previously generated secrets (`CACHIX_SIGNING_KEY` and/or `CACHIX_AUTH_TOKEN`).
+2. Click on `Secrets and variables` and click on `Actions` in dropdown list
+3. Click on `New repository secret`.
+4. Add your previously generated secrets (`CACHIX_SIGNING_KEY` and/or `CACHIX_AUTH_TOKEN`).
 
 ### 3. Setting up GitHub Actions
 


### PR DESCRIPTION
Updated the steps for adding secrets to reflect the correct naming of buttons in the settings menu.

(Personally, with the original guide, I couldn’t figure out where to add secrets the first time.)

<img width="437" height="378" alt="image" src="https://github.com/user-attachments/assets/fbc13635-9680-4b7a-a66b-76d6b7722bca" />

