### PR TITLE
fix(netlify): reverse proxy by download type

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,6 @@
 [[redirects]]
 from = "/manual/nix/unstable/*"
-to = "https://hydra.nixos.org/job/nix/master/manual/latest/download/2/manual/:splat"
+to = "https://hydra.nixos.org/job/nix/master/manual/latest/download-by-type/doc/manual/:splat"
 status = 200
 force = true
 [redirects.headers]
@@ -8,7 +8,7 @@ X-From = "nix.dev-Uogho3gi"
 
 [[redirects]]
 from = "/manual/nix/development/*"
-to = "https://hydra.nixos.org/job/nix/master/manual/latest/download/2/manual/:splat"
+to = "https://hydra.nixos.org/job/nix/master/manual/latest/download-by-type/doc/manual/:splat"
 status = 200
 force = true
 [redirects.headers]


### PR DESCRIPTION
Hydra no longer keeps build byproducts in a deterministic order, so the numeric `download/2` path drifts between `download/1` and `download/2`. This breaks the reverse-proxied Nix manual links whenever the ordering shifts.

Reverse proxy by download type using `download-by-type/doc` instead of the numeric byproduct identifier. The download type resolves to the `doc` output regardless of byproduct ordering, which keeps the manual links stable.

Fix https://github.com/NixOS/nix/issues/16202.